### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/fluent_utils/softdeps/taggit.py
+++ b/fluent_utils/softdeps/taggit.py
@@ -62,7 +62,7 @@ class TagsMixin(models.Model):
 
         # can't filter, see
         # - https://github.com/alex/django-taggit/issues/32
-        # - http://django-taggit.readthedocs.org/en/latest/api.html#TaggableManager.similar_objects
+        # - https://django-taggit.readthedocs.io/en/latest/api.html#TaggableManager.similar_objects
         #
         # Otherwise this would be possible:
         # return tags.similar_objects(**filters)


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
