### PR TITLE
Fix AnyUrlField migration issue on Django 1.11.

### DIFF
--- a/fluent_utils/softdeps/any_urlfield.py
+++ b/fluent_utils/softdeps/any_urlfield.py
@@ -36,5 +36,5 @@ class AnyUrlField(BaseUrlField):
     def deconstruct(self):
         # For Django 1.7 migrations, masquerade as normal URLField too
         name, path, args, kwargs = super(AnyUrlField, self).deconstruct()
-        path = "{0}.{1}".format(models.URLField.__module__, models.URLField.__name__)
+        path = "django.db.models.{}".format(models.URLField.__name__)
         return name, path, args, kwargs


### PR DESCRIPTION
On Django 1.11 `models.URLField.__module__` returns `django.db.models.fields` but the model is setup with `django.db.models` so the migrations are continually generated for the `new_url` field in the fluent-pages app. I'm not sure if this is best approach but it does solve the problem.